### PR TITLE
Feature | Adds record types for service models

### DIFF
--- a/RealTimePassengerInformation.UnitTests/BusUnitTests.fs
+++ b/RealTimePassengerInformation.UnitTests/BusUnitTests.fs
@@ -69,6 +69,12 @@ module Bus =
             Assert.Equal(expectedUri, actualUri)
 
         [<Fact>]
+        let internal ``buildUri_RouteInformation_BuildsExpectedUri`` () =
+            let expectedUri = defaultServiceEndpoint + "/routeinformation?format=json"
+            let actualUri = buildUri defaultServiceEndpoint RouteInformation []
+            Assert.Equal(expectedUri, actualUri)
+
+        [<Fact>]
         let internal ``buildUri_RouteListInformation_BuildsExpectedUri`` () =
             let expectedUri = defaultServiceEndpoint + "/routelistinformation?format=json"
             let actualUri = buildUri defaultServiceEndpoint RouteListInformation []

--- a/RealTimePassengerInformation/Bus.fs
+++ b/RealTimePassengerInformation/Bus.fs
@@ -5,11 +5,26 @@ open System.Globalization
 open System.Runtime.CompilerServices
 
 module Bus =
+    type public BusStopName = {
+        EnglishName : string;
+        IrishName   : string;
+    }
+
+    type public Day =
+        | Sunday    = 0
+        | Monday    = 1
+        | Tuesday   = 2
+        | Wednesday = 3
+        | Thursday  = 4
+        | Friday    = 5
+        | Saturday  = 6
+
     module Service =
         type internal Endpoint =
             | BusStopInformation
             | OperatorInformation
             | RealTimeBusInformation
+            | RouteInformation
             | RouteListInformation
             | TimetableInformation
 
@@ -51,6 +66,104 @@ module Bus =
                     baseUri,
                     apiEndpoint.ToString().ToLowerInvariant(),
                     parameterString)
+
+    module BusStopInformation =
+        type public BusStopOperator = {
+            Name   : string;
+            Routes : string list;
+        }
+
+        type public T = {
+            StopId          : string;
+            DisplayedStopId : string;
+            ShortName       : BusStopName;
+            FullName        : BusStopName;
+            Latitude        : float;
+            Longitude       : float;
+            Operators       : BusStopOperator list;
+        }
+
+    module OperatorInformation =
+        type public T = {
+            ReferenceCode : string;
+            Name          : string;
+            Description   : string;
+        }
+
+    module RealTimeBusInformation =
+        type public RealTimeSlot = {
+            Expected  : DateTime;
+            Scheduled : DateTime;
+        }
+
+        type public RealTimeArrivalInformation = {
+            Arrival               : RealTimeSlot;
+            Departure             : RealTimeSlot;
+            BoardStatus           : string;
+            Origin                : BusStopName;
+            Destination           : BusStopName;
+            Direction             : string;
+            OperatorName          : string;
+            AdditionalInformation : string;
+            HasLowFloor           : bool;
+            Route                 : string;
+        }
+
+        type public T = {
+            StopId   : string;
+            Arrivals : RealTimeArrivalInformation;
+        }
+
+    module RouteInformation =
+        type public BusStopInformation = {
+            StopId          : string;
+            DisplayedStopId : string;
+            ShortName       : BusStopName;
+            FullName        : BusStopName;
+            Latitude        : float;
+            Longitude       : float;
+        }
+
+        type public T = {
+            OperatorName : string;
+            Origin       : BusStopName;
+            Destination  : BusStopName;
+            Stops        : BusStopInformation list;
+        }
+
+    module RouteListInformation =
+        type public T = {
+            OperatorReferenceCode : string;
+            Routes                : string list;
+        }
+
+    module DailyTimeTableInformation =
+        type public TimeTableEntry = {
+            Arrival      : DateTime;
+            Destination  : BusStopName;
+            OperatorName : string;
+            HasLowFloor  : bool;
+            Route        : string;
+        }
+
+        type public T = {
+            StopId           : string;
+            TimeTableEntries : TimeTableEntry list;
+        }
+
+    module FullTimeTableInformation =
+        type public TimeTableEntry = {
+            StartDayOfWeek : Day;
+            EndDayOfWeek   : Day;
+            Destination    : BusStopName;
+            Departures     : TimeSpan list
+        }
+
+        type public T = {
+            StopId           : string;
+            Route            : string;
+            TimeTableEntries : TimeTableEntry list;
+        }
 
 [<assembly: InternalsVisibleTo("RealTimePassengerInformation.UnitTests")>]
 do()


### PR DESCRIPTION
No functionality here, adding the record types to encapsulate service responses and a missing endpoint in the union with a relevant unit test.